### PR TITLE
package to demonstrate the features of movegroup interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES movegroup_interface_tutorial
-  CATKIN_DEPENDS geometry_msgs roscpp
+  CATKIN_DEPENDS geometry_msgs roscpp moveit_ros_planning_interface
 #  DEPENDS system_lib
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,13 +5,9 @@ project(movegroup_interface_demo)
 add_compile_options(-std=c++11)
 
 ## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   geometry_msgs
   roscpp
-  rospy
-  std_msgs
   moveit_ros_planning_interface
 )
 
@@ -28,7 +24,7 @@ find_package(catkin REQUIRED COMPONENTS
 catkin_package(
 #  INCLUDE_DIRS include
 #  LIBRARIES movegroup_interface_tutorial
-#  CATKIN_DEPENDS geometry_msgs roscpp rospy std_msgs
+  CATKIN_DEPENDS geometry_msgs roscpp
 #  DEPENDS system_lib
 )
 
@@ -48,4 +44,3 @@ target_link_libraries(pose_goal ${catkin_LIBRARIES})
 
 add_executable(named_goal src/named_goal.cpp)
 target_link_libraries(named_goal ${catkin_LIBRARIES})
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,51 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(movegroup_interface_demo)
+
+## Compile as C++11, supported in ROS Kinetic and newer
+add_compile_options(-std=c++11)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  geometry_msgs
+  roscpp
+  rospy
+  std_msgs
+  moveit_ros_planning_interface
+)
+
+
+###################################
+## catkin specific configuration ##
+###################################
+## The catkin_package macro generates cmake config files for your package
+## Declare things to be passed to dependent projects
+## INCLUDE_DIRS: uncomment this if your package contains header files
+## LIBRARIES: libraries you create in this project that dependent projects also need
+## CATKIN_DEPENDS: catkin_packages dependent projects also need
+## DEPENDS: system dependencies of this project that dependent projects also need
+catkin_package(
+#  INCLUDE_DIRS include
+#  LIBRARIES movegroup_interface_tutorial
+#  CATKIN_DEPENDS geometry_msgs roscpp rospy std_msgs
+#  DEPENDS system_lib
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+# include
+  ${catkin_INCLUDE_DIRS}
+)
+
+add_executable(pose_goal src/pose_goal.cpp)
+target_link_libraries(pose_goal ${catkin_LIBRARIES})
+
+add_executable(named_goal src/named_goal.cpp)
+target_link_libraries(named_goal ${catkin_LIBRARIES})
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # movegroup_interface_demo
 A package designed to help learning ROS MoveIt Move Group C++ Interface.
 
-Although this package should be usable with any properly setup MoveIt cnofiguration package, the development and testing has been conducted using xArm7 ROS support available at https://github.com/xArm-Developer/xarm_ros
+Although this package should be usable with any properly setup MoveIt configuration package, the development and testing has been conducted using xArm7 ROS support available at https://github.com/xArm-Developer/xarm_ros
 
 ## Running with xArm7
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # movegroup_interface_demo
 A package designed to help learning ROS MoveIt Move Group C++ Interface.
+
+Although this package should be usable with any properly setup MoveIt cnofiguration package, the development and testing has been conducted using xArm7 ROS support available at https://github.com/xArm-Developer/xarm_ros
+
+## Running with xArm7
+
+Clone xarm_ros and movegroup_interface_demo repositories to your catkin workspace and compile it.
+
+```bash
+roslaunch xarm7_moveit_config demo.launch
+```
+
+Demonstration of planning to a ***pose*** goal
+```bash
+rosrun movegroup_interface_demo pose_goal
+```
+
+Demonstration of planning to a ***named*** goal
+```bash
+rosrun movegroup_interface_demo named_goal
+```
+
+## Other robots
+
+In order to use movegroup_interface_demo with other MoveIt planning groups, adjust hard-coded planning group names and pose values in the .cpp files located in src folder.
+
+

--- a/package.xml
+++ b/package.xml
@@ -2,70 +2,23 @@
 <package format="2">
   <name>movegroup_interface_demo</name>
   <version>0.0.0</version>
-  <description>The movegroup_interface_demo package</description>
+  <description>A package designed to help learning ROS MoveIt Move Group C++ Interface</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag -->
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
-  <maintainer email="karl@todo.todo">karl</maintainer>
+  <maintainer email="karl.kruusamae@ut.ee">Karl Kruusamäe</maintainer>
 
+  <license>3-clause BSD</license>
 
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
-  <license>TODO</license>
+  <url type="website">https://github.com/ut-ims-robotics/movegroup_interface_demo</url>
 
+  <author email="karl.kruusamae@ut.ee">Karl Kruusamäe</author>
 
-  <!-- Url tags are optional, but multiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/movegroup_interface_tutorial</url> -->
-
-
-  <!-- Author tags are optional, multiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintainers, but could be -->
-  <!-- Example: -->
-  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
-
-
-  <!-- The *depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
-  <!--   <depend>roscpp</depend> -->
-  <!--   Note that this is equivalent to the following: -->
-  <!--   <build_depend>roscpp</build_depend> -->
-  <!--   <exec_depend>roscpp</exec_depend> -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use build_export_depend for packages you need in order to build against this package: -->
-  <!--   <build_export_depend>message_generation</build_export_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use exec_depend for packages you need at runtime: -->
-  <!--   <exec_depend>message_runtime</exec_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
-  <!-- Use doc_depend for packages you need only for building documentation: -->
-  <!--   <doc_depend>doxygen</doc_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>roscpp</build_depend>
-  <build_depend>rospy</build_depend>
-  <build_depend>std_msgs</build_depend>
+  <build_depend>moveit_ros_planning_interface</build_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
-  <build_export_depend>rospy</build_export_depend>
-  <build_export_depend>std_msgs</build_export_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>roscpp</exec_depend>
-  <exec_depend>rospy</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/package.xml
+++ b/package.xml
@@ -18,7 +18,9 @@
   <build_depend>moveit_ros_planning_interface</build_depend>
   <build_export_depend>geometry_msgs</build_export_depend>
   <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>moveit_ros_planning_interface</build_export_depend>
   <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>roscpp</exec_depend>
+  <exec_depend>moveit_ros_planning_interface</exec_depend>
 
 </package>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>movegroup_interface_demo</name>
+  <version>0.0.0</version>
+  <description>The movegroup_interface_demo package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag -->
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="karl@todo.todo">karl</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but multiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/movegroup_interface_tutorial</url> -->
+
+
+  <!-- Author tags are optional, multiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintainers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use depend as a shortcut for packages that are both build and exec dependencies -->
+  <!--   <depend>roscpp</depend> -->
+  <!--   Note that this is equivalent to the following: -->
+  <!--   <build_depend>roscpp</build_depend> -->
+  <!--   <exec_depend>roscpp</exec_depend> -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use build_export_depend for packages you need in order to build against this package: -->
+  <!--   <build_export_depend>message_generation</build_export_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use exec_depend for packages you need at runtime: -->
+  <!--   <exec_depend>message_runtime</exec_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <!-- Use doc_depend for packages you need only for building documentation: -->
+  <!--   <doc_depend>doxygen</doc_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>geometry_msgs</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>rospy</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_export_depend>geometry_msgs</build_export_depend>
+  <build_export_depend>roscpp</build_export_depend>
+  <build_export_depend>rospy</build_export_depend>
+  <build_export_depend>std_msgs</build_export_depend>
+  <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>roscpp</exec_depend>
+  <exec_depend>rospy</exec_depend>
+  <exec_depend>std_msgs</exec_depend>
+
+
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/src/named_goal.cpp
+++ b/src/named_goal.cpp
@@ -1,0 +1,77 @@
+/*
+Copyright 2019, University of Tartu
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* Author: Karl Kruusamäe */
+/* E-mail: karl.kruusamae@ut.ee */
+
+#include <moveit/move_group_interface/move_group_interface.h>
+
+int main(int argc, char** argv)
+{
+  // Basic ROS setup
+  // ^^^^^^^^^^^^^^^
+  ros::init(argc, argv, "pose_goal");
+  ros::NodeHandle node_handle;
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  // MoveGroupInterface API can be found at:
+  // http://docs.ros.org/kinetic/api/moveit_ros_planning_interface/html/classmoveit_1_1planning__interface_1_1MoveGroupInterface.html
+
+  // MoveIt setup
+  // ^^^^^^^^^^^^
+  // A MoveGroupInterface instance (a client for the MoveGroup action) can be easily setup using just the name of the
+  // planning group you would like to control and plan for.
+  moveit::planning_interface::MoveGroupInterface move_group("xarm7");
+
+  // Planning to a predefined named pose
+  // ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  // We can plan a motion for this group by specifying a target pose from the list of defined poses. The named poses can
+  // be defined for a particular planning group using the MoveIt Setup Assistant.
+
+  // Setting a named pose as target
+  move_group.setNamedTarget("home_pose");
+
+  // Calling the planner to compute the motion plan, which is then stored in my_plan.
+  // Note that we are just planning, not asking MoveGroupInterface to actually move the robot.
+  moveit::planning_interface::MoveGroupInterface::Plan my_plan;
+  moveit::planning_interface::MoveItErrorCode success = move_group.plan(my_plan);
+  if (success)
+  {
+    ROS_INFO("[movegroup_interface_demo/named_goal] Planning OK. Proceeding.");
+  }
+  else
+  {
+    ROS_WARN("[movegroup_interface_demo/named_goal] Planning failed. Shutting Down.");
+    ros::shutdown();
+  }
+
+  // Executing the computed plan
+  // ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  // Uncomment the following line to make the robot move according to the computed plan
+  // move_group.execute(my_plan);
+
+  ros::shutdown();
+  return 0;
+}

--- a/src/named_goal.cpp
+++ b/src/named_goal.cpp
@@ -66,6 +66,7 @@ int main(int argc, char** argv)
   {
     ROS_WARN("[movegroup_interface_demo/named_goal] Planning failed. Shutting Down.");
     ros::shutdown();
+    return 0;
   }
 
   // Executing the computed plan

--- a/src/named_goal.cpp
+++ b/src/named_goal.cpp
@@ -25,13 +25,14 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* Author: Karl Kruusamäe */
 /* E-mail: karl.kruusamae@ut.ee */
 
+#include <ros/ros.h>
 #include <moveit/move_group_interface/move_group_interface.h>
 
 int main(int argc, char** argv)
 {
   // Basic ROS setup
   // ^^^^^^^^^^^^^^^
-  ros::init(argc, argv, "pose_goal");
+  ros::init(argc, argv, "named_goal");
   ros::NodeHandle node_handle;
   ros::AsyncSpinner spinner(1);
   spinner.start();

--- a/src/pose_goal.cpp
+++ b/src/pose_goal.cpp
@@ -25,7 +25,10 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /* Author: Karl Kruusamäe */
 /* E-mail: karl.kruusamae@ut.ee */
 
+#include <ros/ros.h>
 #include <moveit/move_group_interface/move_group_interface.h>
+#include <geometry_msgs/PoseStamped.h>
+#include <geometry_msgs/Pose.h>
 
 int main(int argc, char** argv)
 {

--- a/src/pose_goal.cpp
+++ b/src/pose_goal.cpp
@@ -79,6 +79,7 @@ int main(int argc, char** argv)
   {
     ROS_WARN("[movegroup_interface_demo/pose_goal] Planning failed. Shutting Down.");
     ros::shutdown();
+    return 0;
   }
   
   // Executing the computed plan

--- a/src/pose_goal.cpp
+++ b/src/pose_goal.cpp
@@ -1,0 +1,88 @@
+/*
+Copyright 2019, University of Tartu
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the
+following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following
+disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* Author: Karl Kruusamäe */
+/* E-mail: karl.kruusamae@ut.ee */
+
+#include <moveit/move_group_interface/move_group_interface.h>
+
+int main(int argc, char** argv)
+{
+  // Basic ROS setup
+  // ^^^^^^^^^^^^^^^
+  ros::init(argc, argv, "pose_goal");
+  ros::NodeHandle node_handle;
+  ros::AsyncSpinner spinner(1);
+  spinner.start();
+
+  // MoveGroupInterface API can be found at:
+  // http://docs.ros.org/kinetic/api/moveit_ros_planning_interface/html/classmoveit_1_1planning__interface_1_1MoveGroupInterface.html
+
+  // MoveIt setup
+  // ^^^^^^^^^^^^
+  // A MoveGroupInterface instance (a client for the MoveGroup action) can be easily setup using just the name of the
+  // planning group you would like to control and plan for.
+  moveit::planning_interface::MoveGroupInterface move_group("xarm7");
+
+  // Planning to a pose goal
+  // ^^^^^^^^^^^^^^^^^^^^^^^
+  // We can plan a motion for this group by defining a target pose for the end-effector.
+  // As pose requires 7 variables - x, y, and z for the position and x, y, z, and w for the orientation- to be defined,
+  // it is convenient to first get the current end-effector pose and then modify it to a suitable target pose.
+
+  // Getting the current pose of the end-effector.
+  geometry_msgs::PoseStamped current_pose;
+  current_pose = move_group.getCurrentPose();
+
+  // Modifying the current pose into a target pose.
+  // Feel free to change the following position values to see their influence on the motion planning
+  geometry_msgs::Pose target_pose = current_pose.pose;
+  target_pose.position.x += 0.1;
+  target_pose.position.y += -0.2;
+  target_pose.position.z += -0.0;
+  // Setting the target pose for the end-effector
+  move_group.setPoseTarget(target_pose);
+
+  // Calling the planner to compute the motion plan, which is then stored in my_plan.
+  // Note that we are just planning, not asking MoveGroupInterface to actually move the robot.
+  moveit::planning_interface::MoveGroupInterface::Plan my_plan;
+  moveit::planning_interface::MoveItErrorCode success = move_group.plan(my_plan);
+  if (success)
+  {
+    ROS_INFO("[movegroup_interface_demo/pose_goal] Planning OK. Proceeding.");
+  }
+  else
+  {
+    ROS_WARN("[movegroup_interface_demo/pose_goal] Planning failed. Shutting Down.");
+    ros::shutdown();
+  }
+  
+  // Executing the computed plan
+  // ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  // Uncomment the following line to make the robot move according to the computed plan
+  // move_group.execute(my_plan);
+
+  ros::shutdown();
+  return 0;
+}


### PR DESCRIPTION
the basic idea for this package is to write easy to understand coding examples to illustrate the capabilities of movegroup interface. for that reason:
1) the coding aims to be as minimalistic as possible with easy to understand variable names
2) different movegroup features are exemplified individually in different ROS nodes to make code graspable for beginners in computer programming

here the first two examples are provided: 1) planning to an end-effector pose and 2) planning to a named pose. 